### PR TITLE
Add ASUS mainboard dropdown

### DIFF
--- a/hardware.json
+++ b/hardware.json
@@ -1,0 +1,20 @@
+{
+  "ASUS": {
+    "laptop": {
+      "mainboards": {
+        "ROG STRIX B550": {
+          "cpu": ["Ryzen 5 5600X", "Ryzen 7 5800X"],
+          "ram": ["8GB", "16GB", "32GB"],
+          "gpu": ["RTX 3060", "RTX 3070"],
+          "sound": ["Realtek ALC1220"]
+        },
+        "TUF Gaming B560M": {
+          "cpu": ["Intel i5-11400", "Intel i7-11700"],
+          "ram": ["8GB", "16GB"],
+          "gpu": ["GTX 1660", "RTX 2060"],
+          "sound": ["Realtek ALC897"]
+        }
+      }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ requests
 timezonefinder
 pproxy
 geoip2
+
+pytest

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,19 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location("antic", pathlib.Path(__file__).resolve().parents[1] / "antic.py")
+antic = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(antic)
+
+load_hardware_data = antic.load_hardware_data
+HARDWARE_DATA_PATH = antic.HARDWARE_DATA_PATH
+
+
+def test_load_hardware_data(tmp_path, monkeypatch):
+    # use a temporary path for hardware file
+    temp_file = tmp_path / 'hardware.json'
+    monkeypatch.setattr(antic, 'HARDWARE_DATA_PATH', str(temp_file))
+    data = load_hardware_data()
+    assert 'ASUS' in data
+    assert 'laptop' in data['ASUS']
+    assert 'mainboards' in data['ASUS']['laptop']


### PR DESCRIPTION
## Summary
- allow storing hardware database in `hardware.json`
- load hardware data via new `load_hardware_data` helper
- extend profile config save logic with selected hardware options
- add UI dropdowns to choose ASUS mainboards and compatible components
- add pytest requirement and tests for hardware loader

## Testing
- `pip install -q -r requirements.txt`
- `playwright install chromium` *(fails: no output)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ab4f3bd08320893fdf1285dc0f6f