### PR TITLE
Add laptop model selection UI

### DIFF
--- a/hardware/laptop_models.json
+++ b/hardware/laptop_models.json
@@ -1,0 +1,11 @@
+{
+  "ASUS": {
+    "models": {
+      "Zephyrus G14": {
+        "mainboards": ["ROG STRIX B550"],
+        "mouse": ["Touchpad"],
+        "battery": ["76Wh"]
+      }
+    }
+  }
+}

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -7,6 +7,8 @@ spec.loader.exec_module(antic)
 
 load_hardware_data = antic.load_hardware_data
 HARDWARE_DATA_PATH = antic.HARDWARE_DATA_PATH
+load_laptop_models_data = antic.load_laptop_models_data
+LAPTOP_MODELS_PATH = antic.LAPTOP_MODELS_PATH
 
 
 def test_load_hardware_data(tmp_path, monkeypatch):
@@ -17,3 +19,13 @@ def test_load_hardware_data(tmp_path, monkeypatch):
     assert 'ASUS' in data
     assert 'laptop' in data['ASUS']
     assert 'mainboards' in data['ASUS']['laptop']
+
+
+def test_load_laptop_models_data(tmp_path, monkeypatch):
+    temp_dir = tmp_path / 'hardware'
+    temp_dir.mkdir()
+    temp_file = temp_dir / 'laptop_models.json'
+    monkeypatch.setattr(antic, 'LAPTOP_MODELS_PATH', str(temp_file))
+    data = load_laptop_models_data()
+    assert 'ASUS' in data
+    assert 'models' in data['ASUS']


### PR DESCRIPTION
## Summary
- add ability to load laptop models from `hardware/laptop_models.json`
- show manufacturer/model pickers in configuration UI
- display mouse and battery options based on selected model
- store the new settings when saving a profile
- include tests for loading laptop model data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ad8f9f988320aa20af33cd6b44c0