### PR TITLE
Implement dynamic device selection and enhance tests

### DIFF
--- a/hardware.json
+++ b/hardware.json
@@ -16,5 +16,17 @@
         }
       }
     }
+  },
+  "APPLE": {
+    "laptop": {
+      "mainboards": {
+        "M1": {
+          "cpu": ["Apple M1"],
+          "ram": ["8GB", "16GB"],
+          "gpu": ["Integrated"],
+          "sound": ["Apple Sound"]
+        }
+      }
+    }
   }
 }

--- a/hardware/devices.json
+++ b/hardware/devices.json
@@ -1,0 +1,18 @@
+{
+  "Windows": {
+    "laptop": ["ASUS", "APPLE"],
+    "pc": ["ASUS"]
+  },
+  "MacOS": {
+    "laptop": ["APPLE"]
+  },
+  "Linux": {
+    "laptop": ["ASUS"]
+  },
+  "iOS": {
+    "phone": ["APPLE"]
+  },
+  "Android": {
+    "phone": ["Google"]
+  }
+}

--- a/hardware/laptop_models.json
+++ b/hardware/laptop_models.json
@@ -7,5 +7,14 @@
         "battery": ["76Wh"]
       }
     }
+  },
+  "APPLE": {
+    "models": {
+      "MacBook Air": {
+        "mainboards": ["M1"],
+        "mouse": ["Touchpad"],
+        "battery": ["49.9Wh"]
+      }
+    }
   }
 }

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -9,6 +9,8 @@ load_hardware_data = antic.load_hardware_data
 HARDWARE_DATA_PATH = antic.HARDWARE_DATA_PATH
 load_laptop_models_data = antic.load_laptop_models_data
 LAPTOP_MODELS_PATH = antic.LAPTOP_MODELS_PATH
+load_device_data = antic.load_device_data
+DEVICE_DATA_PATH = antic.DEVICE_DATA_PATH
 
 
 def test_load_hardware_data(tmp_path, monkeypatch):
@@ -29,3 +31,12 @@ def test_load_laptop_models_data(tmp_path, monkeypatch):
     data = load_laptop_models_data()
     assert 'ASUS' in data
     assert 'models' in data['ASUS']
+
+
+def test_load_device_data(tmp_path, monkeypatch):
+    temp_dir = tmp_path / 'hardware'
+    temp_dir.mkdir()
+    temp_file = temp_dir / 'devices.json'
+    monkeypatch.setattr(antic, 'DEVICE_DATA_PATH', str(temp_file))
+    data = load_device_data()
+    assert 'Windows' in data


### PR DESCRIPTION
## Summary
- add hardware devices data
- load device mapping in app
- extend configuration UI with OS and device type dropdowns
- adapt hardware dropdown logic accordingly
- ensure data files are created if missing
- cover new loader via unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b05952a88320ae0195cc545a200c